### PR TITLE
Vendor JSONArguments to JSONToWritableMap

### DIFF
--- a/android/src/main/java/com/wearconnectivity/JSONToWritableMap.java
+++ b/android/src/main/java/com/wearconnectivity/JSONToWritableMap.java
@@ -1,0 +1,47 @@
+package com.wearconnectivity;
+
+import java.util.Iterator;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class JSONToWritableMap {
+    
+  /**
+   * Parse JSONObject to ReadableMap
+   *
+   * @param obj The JSONObject to be parsed
+   * @return readableMap from the JSONObject
+   */
+  public static ReadableMap fromJSONObject(JSONObject obj) throws JSONException {
+    WritableMap result = Arguments.createMap();
+    Iterator<String> keys = obj.keys();
+
+    while (keys.hasNext()) {
+      String key = keys.next();
+      Object val = obj.get(key);
+      if (val instanceof JSONObject) {
+        result.putMap(key, fromJSONObject((JSONObject) val));
+      } else if (val instanceof JSONArray) {
+        result.putArray(key, fromJSONArray((JSONArray) val));
+      } else if (val instanceof String) {
+        result.putString(key, (String) val);
+      } else if (val instanceof Boolean) {
+        result.putBoolean(key, (Boolean) val);
+      } else if (val instanceof Integer) {
+        result.putInt(key, (Integer) val);
+      } else if (val instanceof Double) {
+        result.putDouble(key, (Double) val);
+      } else if (val instanceof Long) {
+        result.putInt(key, ((Long) val).intValue());
+      } else if (obj.isNull(key)) {
+        result.putNull(key);
+      } else {
+        // Unknown value type. Will throw
+        throw new JSONException("Unexpected value when parsing JSON object. key: " + key);
+      }
+    }
+
+    return result;
+  }
+}

--- a/android/src/main/java/com/wearconnectivity/WearConnectivityMessageClient.java
+++ b/android/src/main/java/com/wearconnectivity/WearConnectivityMessageClient.java
@@ -11,7 +11,6 @@ import androidx.annotation.RequiresApi;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
-import com.facebook.react.bridge.JSONArguments;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
@@ -67,7 +66,7 @@ public class WearConnectivityMessageClient implements MessageClient.OnMessageRec
     public void onMessageReceived(@NonNull MessageEvent messageEvent) {
         try {
             JSONObject jsonObject = new JSONObject(messageEvent.getPath());
-            WritableMap messageAsWritableMap = (WritableMap) JSONArguments.fromJSONObject(jsonObject);
+            WritableMap messageAsWritableMap = (WritableMap) JSONToWritableMap.fromJSONObject(jsonObject);
             String event = jsonObject.getString("event");
             FLog.w(TAG, TAG + " event: " + event + " message: " + messageAsWritableMap);
             Intent service = new Intent(reactContext, com.wearconnectivity.WearConnectivityTask.class);


### PR DESCRIPTION
I'm looking into making the class `com.facebook.react.bridge.JSONArguments` internal.
This is the only usage I've found of such class in OSS.

Here I'm copying over the code that you're using for the method `fromJSONObject` only.