### PR TITLE
feat: add Garmin connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,28 @@ Add the following entry to your `android/app/src/main/AndroidManifest.xml` (full
 </manifest>
 ```
 
+### Garmin setup
+
+To enable Garmin devices, install the Garmin connector and include the Garmin
+SDK binaries in your project:
+
+```sh
+yarn add react-native-garmin-connect
+```
+
+Download the Garmin SDK from the Garmin developer portal and copy the provided
+`ConnectIQ.jar` (or latest `.aar`) into your `android/app/libs` directory.  Add
+the dependency inside `android/app/build.gradle`:
+
+```gradle
+dependencies {
+  implementation files('libs/ConnectIQ.jar')
+}
+```
+
+Rebuild the Android project after adding the SDK files to ensure the Garmin
+library is linked correctly.
+
 ## React Native API Documentation
 
 The example of implementation available in the [CounterScreen](example/src/CounterScreen/index.android.tsx).

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "url": "https://github.com/fabOnReact/react-native-wear-connectivity/issues"
   },
   "homepage": "https://github.com/fabOnReact/react-native-wear-connectivity#readme",
+  "dependencies": {
+    "react-native-garmin-connect": "^0.1.0"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },

--- a/src/garmin/GarminConnector.ts
+++ b/src/garmin/GarminConnector.ts
@@ -1,0 +1,44 @@
+import { NativeEventEmitter } from 'react-native';
+import GarminConnect from 'react-native-garmin-connect';
+
+/**
+ * Provides a small wrapper around the Garmin Connect SDK.
+ * The connector exposes a simple API used by the library to
+ * communicate with Garmin wearables.
+ */
+class GarminConnector {
+  private emitter: NativeEventEmitter;
+
+  constructor() {
+    // GarminConnect is a native module; wrap it with an event emitter so we
+    // can subscribe to SDK events from JavaScript.
+    this.emitter = new NativeEventEmitter(GarminConnect as any);
+  }
+
+  /**
+   * Initializes the Garmin SDK.
+   */
+  initialize(): Promise<void> {
+    // The SDK exposes an initialize call which prepares the connection layer.
+    return GarminConnect.initialize();
+  }
+
+  /**
+   * Sends a payload to a paired Garmin device.
+   */
+  sendMessage(message: Record<string, unknown>): Promise<void> {
+    return GarminConnect.sendMessage(message);
+  }
+
+  /**
+   * Adds a listener for incoming messages from the Garmin device.
+   * Returns an unsubscribe function to remove the listener.
+   */
+  onMessage(callback: (message: any) => void): () => void {
+    const subscription = this.emitter.addListener('message', callback);
+    return () => subscription.remove();
+  }
+}
+
+export default new GarminConnector();
+

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,6 +38,7 @@ const startFileTransfer: SendFile = (file, _metadata) => {
 };
 
 export { startFileTransfer, sendMessage, watchEvents, WearConnectivity };
+export { default as GarminConnector } from './garmin/GarminConnector';
 export type { ReplyCallback, ErrorCallback };
 
 type WearParameters = {


### PR DESCRIPTION
## Summary
- install Garmin connector package
- add GarminConnector wrapper around Garmin SDK
- document Garmin SDK setup in README

## Testing
- `yarn test` *(fails: Cannot find module '@react-native/babel-preset')*
- `yarn lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-ft-flow")*

------
https://chatgpt.com/codex/tasks/task_e_68b70272d14083208e9a5c615a5f92e1