### PR TITLE
feat: add core watch interfaces and device stubs

### DIFF
--- a/src/applewatch/index.ts
+++ b/src/applewatch/index.ts
@@ -1,0 +1,17 @@
+import type { IWatchConnector } from '../core';
+
+export class AppleWatchConnector implements IWatchConnector {
+  async connect(): Promise<void> {
+    // TODO: implement Apple Watch-specific connection logic
+  }
+
+  async disconnect(): Promise<void> {
+    // TODO: implement Apple Watch-specific disconnection logic
+  }
+
+  isConnected(): boolean {
+    return false;
+  }
+}
+
+export default AppleWatchConnector;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,17 @@
+export interface IWatchConnector {
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  isConnected(): boolean;
+}
+
+export interface IDataSync {
+  syncData(data: unknown): Promise<void>;
+  fetchData(): Promise<unknown>;
+}
+
+export interface IWatchEventHandlers {
+  onConnect?(): void;
+  onDisconnect?(): void;
+  onMessage?(data: unknown): void;
+  onError?(error: Error): void;
+}

--- a/src/garmin/index.ts
+++ b/src/garmin/index.ts
@@ -1,0 +1,17 @@
+import type { IWatchConnector } from '../core';
+
+export class GarminConnector implements IWatchConnector {
+  async connect(): Promise<void> {
+    // TODO: implement Garmin-specific connection logic
+  }
+
+  async disconnect(): Promise<void> {
+    // TODO: implement Garmin-specific disconnection logic
+  }
+
+  isConnected(): boolean {
+    return false;
+  }
+}
+
+export default GarminConnector;

--- a/src/huawei/index.ts
+++ b/src/huawei/index.ts
@@ -1,0 +1,17 @@
+import type { IWatchConnector } from '../core';
+
+export class HuaweiConnector implements IWatchConnector {
+  async connect(): Promise<void> {
+    // TODO: implement Huawei-specific connection logic
+  }
+
+  async disconnect(): Promise<void> {
+    // TODO: implement Huawei-specific disconnection logic
+  }
+
+  isConnected(): boolean {
+    return false;
+  }
+}
+
+export default HuaweiConnector;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,13 @@ import { AppRegistry } from 'react-native';
 import { NativeModules, Platform } from 'react-native';
 import { watchEvents } from './subscriptions';
 import { sendMessage } from './messages';
+// Re-export shared interfaces and device connectors
+export * from './core';
+export * from './garmin';
+export * from './miband';
+export * from './huawei';
+export * from './wearos';
+export * from './applewatch';
 import type {
   ReplyCallback,
   ErrorCallback,

--- a/src/miband/index.ts
+++ b/src/miband/index.ts
@@ -1,0 +1,17 @@
+import type { IWatchConnector } from '../core';
+
+export class MiBandConnector implements IWatchConnector {
+  async connect(): Promise<void> {
+    // TODO: implement Mi Band-specific connection logic
+  }
+
+  async disconnect(): Promise<void> {
+    // TODO: implement Mi Band-specific disconnection logic
+  }
+
+  isConnected(): boolean {
+    return false;
+  }
+}
+
+export default MiBandConnector;

--- a/src/wearos/index.ts
+++ b/src/wearos/index.ts
@@ -1,0 +1,17 @@
+import type { IWatchConnector } from '../core';
+
+export class WearOSConnector implements IWatchConnector {
+  async connect(): Promise<void> {
+    // TODO: implement Wear OS-specific connection logic
+  }
+
+  async disconnect(): Promise<void> {
+    // TODO: implement Wear OS-specific disconnection logic
+  }
+
+  isConnected(): boolean {
+    return false;
+  }
+}
+
+export default WearOSConnector;


### PR DESCRIPTION
## Summary
- add core TypeScript interfaces for connectors, data sync, and event handlers
- scaffold device directories for Garmin, Mi Band, Huawei, WearOS, and Apple Watch adapters
- update entrypoint to expose core interfaces and device adapters

## Testing
- `yarn lint` *(fails: ESLint couldn't find plugin "eslint-plugin-ft-flow")*
- `yarn add -D eslint-plugin-ft-flow` *(fails: Errors happened when preparing the environment)*
- `yarn test` *(fails: Cannot find module '@react-native/babel-preset')*
- `yarn add -D @react-native/babel-preset` *(fails: Errors happened when preparing the environment)*
- `yarn typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b7026ff0fc83209ec3f15673729d32