### PR TITLE
fix: notify when no nearby nodes found

### DIFF
--- a/android/src/main/java/com/wearconnectivity/WearConnectivityMessageClient.java
+++ b/android/src/main/java/com/wearconnectivity/WearConnectivityMessageClient.java
@@ -55,6 +55,7 @@ public class WearConnectivityMessageClient implements MessageClient.OnMessageRec
                 return;
             }
         }
+        errorCb.invoke("No nearby nodes found");
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure sendMessage invokes error callback when no nearby nodes are available

## Testing
- `yarn lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-ft-flow")*
- `yarn test` *(fails: Cannot find module '@react-native/babel-preset')*
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b701f5c1a08320a23f4b80dbcac886