### PR TITLE
feat(android): update service permissions

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,10 +3,14 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <service android:name="com.wearconnectivity.WearConnectivityTask"
-        android:permission="android.permission.BIND_JOB_SERVICE"
-        android:exported="true"  />
-    <intent-filter>
-      <action android:name="com.facebook.react.HeadlessJsTaskService" />
-    </intent-filter>
+        android:permission="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"
+        android:exported="false"
+        android:foregroundServiceType="dataSync|connectedDevice">
+      <intent-filter>
+        <action android:name="com.facebook.react.HeadlessJsTaskService" />
+      </intent-filter>
+    </service>
 </manifest>


### PR DESCRIPTION
## Summary
- add data sync and connected device foreground service permissions
- tighten WearConnectivityTask service attributes for FGS

## Testing
- `yarn lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-ft-flow"; installation attempt failed due to network restrictions)*
- `yarn typecheck`
- `yarn test` *(fails: Cannot find module '@react-native/babel-preset'; installation attempt failed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68b702ef4f748320a918e27ad55fc3b8