### PR TITLE
feat: add huawei wear engine support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Allows you to connect React Native Mobile apps with WearOS.
 - [Jetpack Compose API Documentation](#jetpack-compose-api-documentation)
 - [How to run the example](#how-to-run-the-example)
 - [Alternative methods of installation](#alternative-methods-of-installation)
+- [Huawei Setup](#huawei-setup)
 - [FAQ on Troubleshooting Errors](#faq-on-troubleshooting-errors)
 - [Contributing](#contributing)
 
@@ -320,6 +321,10 @@ You can copy the [implementation](https://github.com/fabOnReact/wearos-communica
 ## Alternative methods of installation
 
 The instructions for writing the WearOS apps with react-native are available at [alternative-installation.md](docs/alternative-installation.md). React Native does not officially support WearOS, some essential components like CircularScrollView are not available in React Native. More info in Issues https://github.com/fabOnReact/react-native-wear-connectivity/issues/12 and https://github.com/andrew-levy/jetpack-compose-react-native/issues/9.
+
+## Huawei Setup
+
+Instructions for integrating Huawei wearables and HMS Core are available in [docs/huawei-setup.md](docs/huawei-setup.md).
 
 ## FAQ on Troubleshooting Errors
 

--- a/android/agconnect-services.json
+++ b/android/agconnect-services.json
@@ -1,0 +1,12 @@
+{
+  "app_id": "00000000000000000000000000000000",
+  "cp_id": "00000000000000000000000000000000",
+  "client": {
+    "client_info": {
+      "mobilesdk_app_id": "00000000000000000000000000000000",
+      "package_name": "com.example.app"
+    },
+    "oauth_client": []
+  },
+  "configuration_version": "1.0"
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,10 +2,12 @@ buildscript {
   repositories {
     google()
     mavenCentral()
+    maven { url 'https://developer.huawei.com/repo/' }
   }
 
   dependencies {
     classpath "com.android.tools.build:gradle:7.2.1"
+    classpath 'com.huawei.agconnect:agcp:1.9.1.301'
   }
 }
 
@@ -14,6 +16,7 @@ def isNewArchitectureEnabled() {
 }
 
 apply plugin: "com.android.library"
+apply plugin: 'com.huawei.agconnect'
 
 if (isNewArchitectureEnabled()) {
   apply plugin: "com.facebook.react"
@@ -93,6 +96,7 @@ android {
 repositories {
   mavenCentral()
   google()
+  maven { url 'https://developer.huawei.com/repo/' }
 }
 
 
@@ -102,6 +106,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation 'com.google.android.gms:play-services-wearable:18.1.0'
+  implementation 'com.huawei.hms:wearengine:5.0.0.300'
 }
 
 if (isNewArchitectureEnabled()) {

--- a/docs/huawei-setup.md
+++ b/docs/huawei-setup.md
@@ -1,0 +1,21 @@
+# Huawei Setup
+
+To use Huawei wearables with this library you must configure Huawei Mobile Services (HMS) and pair the watch with your phone.
+
+## HMS Core configuration
+
+1. Create an app in the [Huawei Developer Console](https://developer.huawei.com/).  
+2. Download the `agconnect-services.json` file and place it in your Android project under `android/agconnect-services.json`.
+3. Ensure the following are added to your `android/build.gradle`:
+   - `maven { url 'https://developer.huawei.com/repo/' }`
+   - `classpath 'com.huawei.agconnect:agcp:1.9.1.301'`
+   - `implementation 'com.huawei.hms:wearengine:5.0.0.300'`
+4. Apply the `com.huawei.agconnect` plugin and sync your project.
+
+## Pairing the watch
+
+1. Install the Huawei Health app on your mobile device.
+2. Sign in with your Huawei ID and add your wearable device.
+3. Ensure the watch is connected via Bluetooth before testing message or file transfer APIs.
+
+These steps prepare the environment so `react-native-wear-engine` can communicate with the paired Huawei watch through this library's unified API.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
+  "dependencies": {
+    "react-native-wear-engine": "^1.0.0"
+  },
   "devDependencies": {
     "@commitlint/config-conventional": "^17.0.2",
     "@react-native/eslint-config": "^0.72.2",

--- a/src/huawei/HuaweiConnector.ts
+++ b/src/huawei/HuaweiConnector.ts
@@ -1,0 +1,40 @@
+import { DeviceEventEmitter } from 'react-native';
+import type { Payload } from '../NativeWearConnectivity';
+
+let WearEngine: any;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  WearEngine = require('react-native-wear-engine');
+} catch (e) {
+  // Module might not be available in development environments.
+  WearEngine = null;
+}
+
+/**
+ * Maps Huawei Wear Engine callbacks to the library unified events.
+ * Call this once when the app starts to bridge incoming messages.
+ */
+export function registerHuaweiListeners() {
+  if (!WearEngine || !WearEngine.addListener) {
+    return;
+  }
+
+  WearEngine.addListener('message', (payload: Payload) => {
+    DeviceEventEmitter.emit('message', payload);
+  });
+
+  WearEngine.addListener('fileTransfer', (event: any) => {
+    DeviceEventEmitter.emit('FileTransferEvent', event);
+  });
+}
+
+/**
+ * Sends a message to the connected Huawei wearable using Wear Engine.
+ */
+export function sendHuaweiMessage(message: Payload) {
+  if (!WearEngine || !WearEngine.sendMessage) {
+    return Promise.reject('react-native-wear-engine not available');
+  }
+
+  return WearEngine.sendMessage(message);
+}


### PR DESCRIPTION
## Summary
- add `react-native-wear-engine` dependency and HMS build configuration
- expose Huawei connector bridging Wear Engine events to unified API
- document Huawei setup and HMS requirements

## Testing
- `yarn lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-ft-flow")*
- `yarn test` *(fails: Cannot find module '@react-native/babel-preset')*

------
https://chatgpt.com/codex/tasks/task_e_68b70276d4408320968e1467a5a91c39