### PR TITLE
feat: add Mi Band connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Allows you to connect React Native Mobile apps with WearOS.
 # Table of Contents
 
 - [Installation](#installation)
+- [Mi Band Setup](#mi-band-setup)
 - [React Native API Documentation](#react-native-api-documentation)
 - [Jetpack Compose API Documentation](#jetpack-compose-api-documentation)
 - [How to run the example](#how-to-run-the-example)
@@ -68,6 +69,15 @@ Add the following entry to your `android/app/src/main/AndroidManifest.xml` (full
     </application>
 </manifest>
 ```
+
+## Mi Band Setup
+
+To use a Mi Band with this library the band must first be paired with the
+Android device through the official **Mi Fitness** (or **Zepp Life**)
+application. Ensure Bluetooth is enabled and grant the app the required
+permissions such as `BLUETOOTH_CONNECT`, `BLUETOOTH_SCAN` and
+`ACCESS_FINE_LOCATION`. More details are available in
+[docs/miband.md](docs/miband.md).
 
 ## React Native API Documentation
 

--- a/docs/miband.md
+++ b/docs/miband.md
@@ -1,0 +1,14 @@
+# Mi Band Setup
+
+To connect a Mi Band device with this library:
+
+1. Pair the band with your Android phone using the official **Mi Fitness** (or **Zepp Life**) application.
+2. Ensure Bluetooth is enabled and the band is connected before launching your React Native app.
+3. Grant the application the required permissions:
+   - `android.permission.BLUETOOTH_CONNECT`
+   - `android.permission.BLUETOOTH_SCAN`
+   - `android.permission.ACCESS_FINE_LOCATION` (required for Bluetooth Low Energy scanning on older Android versions)
+   - `android.permission.BODY_SENSORS` if accessing heart rate or other biometric data
+   - `android.permission.POST_NOTIFICATIONS` to receive notifications on recent Android versions
+
+Without pairing through the Mi Fitness application the device will not accept connections from third‑party apps.

--- a/package.json
+++ b/package.json
@@ -85,6 +85,9 @@
     "react": "*",
     "react-native": "*"
   },
+  "dependencies": {
+    "rn-miband-connector": "^0.1.0"
+  },
   "workspaces": [
     "example",
     "watch-example"

--- a/src/miband/MiBandConnector.ts
+++ b/src/miband/MiBandConnector.ts
@@ -1,0 +1,43 @@
+import { EventEmitter } from 'events';
+import type { AddListener, WatchEvents } from '../types';
+// The rn-miband-connector library exposes an EventEmitter that
+// delivers raw Mi Band events. We translate those events to the
+// shared `watchEvents` interface used by this project.
+//
+// We keep the dependency typed as `any` to avoid requiring its
+// TypeScript definitions.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const MiBand: any = require('rn-miband-connector');
+
+const miband = new MiBand();
+const emitter = new EventEmitter();
+
+// Forward any event from the Mi Band library as a `message` event so
+// that consumers can subscribe via `watchEvents.on('message', cb)`.
+miband.on('data', (payload: unknown) => {
+  emitter.emit('message', payload);
+});
+
+// Some implementations might emit a generic `event` callback instead
+// of `data`. Handle that as well.
+miband.on('event', (payload: unknown) => {
+  emitter.emit('message', payload);
+});
+
+const addListener: AddListener = (event, cb) => {
+  if (event !== 'message') {
+    throw new Error(`Unknown watch event "${event}"`);
+  }
+
+  emitter.on(event, cb);
+  return () => {
+    emitter.removeListener(event, cb);
+  };
+};
+
+export const mibandEvents: WatchEvents = {
+  addListener,
+  on: addListener,
+};
+
+export default mibandEvents;

--- a/src/miband/rn-miband-connector.d.ts
+++ b/src/miband/rn-miband-connector.d.ts
@@ -1,0 +1,1 @@
+declare module 'rn-miband-connector';


### PR DESCRIPTION
## Summary
- add Mi Band connector translating library events to `watchEvents`
- document Mi Band pairing requirements and permissions

## Testing
- `yarn lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-ft-flow")*
- `yarn typecheck`
- `yarn test` *(fails: Cannot find module '@react-native/babel-preset')*

------
https://chatgpt.com/codex/tasks/task_e_68b70274f8848320a3cca865b567ffb2